### PR TITLE
Setup GitHub Actions to update the add-on reports automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,10 @@ updates:
     directory: "/add-on-reports-generator"
     schedule:
       interval: "weekly"
-updates:
+  - package-ecosystem: "npm"
+    directory: "/bugzilla-contribution-generator"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/add-on-reports-generator"
+    schedule:
+      interval: "weekly"
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,28 @@
+name: Update
+
+on:
+  schedule:
+    - cron:  '0 12 * * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    name: Update add-on reports
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+    - name: Install
+      run: |
+        cd add-on-reports-generator
+        npm ci
+    - name: Run
+      run: |
+        cd add-on-reports-generator
+        node get_addon_data.js
+        node build_reports.js
+        git config --global user.email "john.bieling@gmx.de"
+        git config --global user.name "John Bieling"
+        git commit -am "Updated add-on reports $(date -u +%F)."
+        git push

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -11,8 +11,8 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
     - name: Install
       run: |
         cd add-on-reports-generator
@@ -24,5 +24,8 @@ jobs:
         node build_reports.js
         git config --global user.email "john.bieling@gmx.de"
         git config --global user.name "John Bieling"
+        if git diff --quiet; then
+            exit 0
+        fi
         git commit -am "Updated add-on reports $(date -u +%F)."
         git push

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  update:
+  update-add-on-reports:
     name: Update add-on reports
 
     runs-on: ubuntu-latest
@@ -28,4 +28,30 @@ jobs:
             exit 0
         fi
         git commit -am "Updated add-on reports $(date -u +%F)."
+        git push
+
+  update-bugzilla-contribution:
+    name: Update Bugzilla contribution
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+    - name: Install
+      run: |
+        cd bugzilla-contribution-generator
+        npm ci
+    - name: Run
+      run: |
+        cd bugzilla-contribution-generator
+        node get_bugzilla_data.js "Thunderbird" "2020-01-01"
+        node get_bugzilla_data.js "Calendar" "2020-01-01"
+        node get_bugzilla_data.js "MailNews Core" "2020-01-01"
+        node bugzilla_report.js data/*
+        git config --global user.email "john.bieling@gmx.de"
+        git config --global user.name "John Bieling"
+        if git diff --quiet; then
+            exit 0
+        fi
+        git commit -am "Updated Bugzilla contribution report $(date -u +%F)."
         git push

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -13,6 +13,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
+      with:
+        cache: 'npm'
+        cache-dependency-path: add-on-reports-generator/package-lock.json
+    - uses: actions/cache@v4
+      with:
+        path: add-on-reports-generator/data/
+        key: add-on-reports-generator-data
     - name: Install
       run: |
         cd add-on-reports-generator
@@ -28,6 +35,7 @@ jobs:
             exit 0
         fi
         git commit -am "Updated add-on reports $(date -u +%F)."
+        git pull --rebase
         git push
 
   update-bugzilla-contribution:
@@ -37,6 +45,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
+      with:
+        cache: 'npm'
+        cache-dependency-path: bugzilla-contribution-generator/package-lock.json
+    - uses: actions/cache@v4
+      with:
+        path: bugzilla-contribution-generator/data/
+        key: bugzilla-contribution-generator-data
     - name: Install
       run: |
         cd bugzilla-contribution-generator
@@ -44,9 +59,9 @@ jobs:
     - name: Run
       run: |
         cd bugzilla-contribution-generator
-        node get_bugzilla_data.js "Thunderbird" "2020-01-01"
-        node get_bugzilla_data.js "Calendar" "2020-01-01"
-        node get_bugzilla_data.js "MailNews Core" "2020-01-01"
+        for product in "Thunderbird" "Calendar" "MailNews Core"; do
+            node get_bugzilla_data.js "$product" "2020-01-01"
+        done
         node bugzilla_report.js data/*
         git config --global user.email "john.bieling@gmx.de"
         git config --global user.name "John Bieling"
@@ -54,4 +69,5 @@ jobs:
             exit 0
         fi
         git commit -am "Updated Bugzilla contribution report $(date -u +%F)."
+        git pull --rebase
         git push


### PR DESCRIPTION
* Setup GitHub Actions to update the add-on reports automatically. Fixes #1
  * This will automatically update the add-on reports everyday at around noon (12:00) UTC.
  * The commits will be attributed to you (@jobisoft). Please let me know if you would prefer a different time or a different commit message.
* Setup [Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) to update the dependencies.
  * This will automatically create PRs when needed to update both the new GitHub Action and existing NPM dependencies.
  * It looks like a couple of the NPM packages are currently outdated, so merging this should trigger a new PR from Dependabot.